### PR TITLE
Add space in ".NET Core" display strings

### DIFF
--- a/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/source.extension.vsixmanifest
+++ b/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/source.extension.vsixmanifest
@@ -2,8 +2,8 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
     <Identity Id="Microsoft.NetCore.CSharp.ProjectTemplates.Desktop" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
-    <DisplayName>C# .NETCore Desktop Project Templates</DisplayName>
-    <Description>C# project templates for .NETCore Desktop.</Description>
+    <DisplayName>C# .NET Core Desktop Project Templates</DisplayName>
+    <Description>C# project templates for .NET Core Desktop.</Description>
   </Metadata>
   <Installation SystemComponent="true" Experimental="true">
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.Pro" />


### PR DESCRIPTION
Follows #71.