### PR TITLE
Winforms default name update

### DIFF
--- a/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/Winforms.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/Winforms.vstemplate
@@ -10,7 +10,7 @@
     <TemplateID>Microsoft.CSharp.NETCore.Winforms</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <CreateInPlace>true</CreateInPlace>
-    <DefaultName>ConsoleApp</DefaultName>
+    <DefaultName>WindowsFormsApp</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
   </TemplateData>

--- a/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/Winforms.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/Winforms.vstemplate
@@ -10,7 +10,7 @@
     <TemplateID>Microsoft.CSharp.NETCore.Winforms</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <CreateInPlace>true</CreateInPlace>
-    <DefaultName>WindowsFormsApp</DefaultName>
+    <DefaultName>ConsoleApp</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
   </TemplateData>


### PR DESCRIPTION
The current template was using the default name as ConsoleApp. This updates it to WindowsFormsApp.