### PR TITLE
Show .NET Core WPF template in Blend

### DIFF
--- a/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/Wpf.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/Wpf.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>WpfApp</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <AppIdFilter>blend</AppIdFilter>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>


### PR DESCRIPTION
Add <AppIdFilter>blend</AppIdFilter> in .NET Core WPF template so it appears in Blend

Fixes issue #76