### PR TITLE
Missed Changing version.props file  while migrating to ML.Net 0.11

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -20,8 +20,8 @@
     -->
     <MicroBuildPluginsSwixBuildVersion>1.0.422</MicroBuildPluginsSwixBuildVersion>
 
-    <MicrosoftMLVersion>0.10.0</MicrosoftMLVersion>
-    <MicrosoftMLCpuMathVersion>0.10.0</MicrosoftMLCpuMathVersion>
+    <MicrosoftMLVersion>0.11.0</MicrosoftMLVersion>
+    <MicrosoftMLCpuMathVersion>0.11.0</MicrosoftMLCpuMathVersion>
 
     <!-- VS SDK -->
     <VSLangProjVersion>7.0.3300</VSLangProjVersion>


### PR DESCRIPTION
Changed version.props file to Ml.Net 0.11