### PR TITLE
 Properly determine the path for a new .editorconfig

### DIFF
--- a/src/Tools/Microsoft.VisualStudio.Templates.Editorconfig.Wizard/EditorConfigFileGenerator.cs
+++ b/src/Tools/Microsoft.VisualStudio.Templates.Editorconfig.Wizard/EditorConfigFileGenerator.cs
@@ -53,10 +53,22 @@ namespace Templates.EditorConfig.FileGenerator
                 selectedItem = selItem.Object;
                 if (selItem.Object is ProjectItem item && item.Properties != null)
                 {
-                    return (selectedItem != null, item.Properties.Item("FullPath").Value.ToString(), false, selectedItem);
+                    if (item.Kind.Equals(Constants.vsProjectItemKindPhysicalFolder, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // The selected item is a folder; add the .editorconfig file to the folder.
+                        var directoryPath = item.Properties.Item("FullPath").Value.ToString();
+                        return (selectedItem != null, directoryPath, false, selectedItem);
+                    }
+                    else if (item.Kind.Equals(Constants.vsProjectItemKindPhysicalFile, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // The selected item is a file; add the .editorconfig file to the same folder.
+                        var directoryPath = Path.GetDirectoryName(item.Properties.Item("FullPath").Value.ToString());
+                        return (selectedItem != null, directoryPath, false, selectedItem);
+                    }
                 }
                 else if (selItem.Object is Project proj && proj.Kind != "{66A26720-8FB5-11D2-AA7E-00C04F688DDE}") // solution folder
                 {
+                    // The selected item is a project; add the .editorconfig to the project's root.
                     (bool success, string rootFolder) = proj.TryGetRootFolder(_dte.Solution.FullName);
                     return (success && selectedItem != null, rootFolder, true, selectedItem);
                 }

--- a/src/Tools/Microsoft.VisualStudio.Templates.Editorconfig.Wizard/Microsoft.VisualStudio.Templates.Editorconfig.Wizard.csproj
+++ b/src/Tools/Microsoft.VisualStudio.Templates.Editorconfig.Wizard/Microsoft.VisualStudio.Templates.Editorconfig.Wizard.csproj
@@ -39,7 +39,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Update="WizardResource.resx">
+    <EmbeddedResource Include="WizardResource.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>WizardResource.Designer.cs</LastGenOutput>
     </EmbeddedResource>

--- a/src/Tools/Microsoft.VisualStudio.Templates.Editorconfig.Wizard/WizardResource.Designer.cs
+++ b/src/Tools/Microsoft.VisualStudio.Templates.Editorconfig.Wizard/WizardResource.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.Templates.Editorconfig.Wizard {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class WizardResource {


### PR DESCRIPTION
Fixes AB#850362.

Currently, if you select an existing file in Solution Explorer and use Ctrl+Shift+A to try to add a .editorconfig file you'll see a dialog pop up with an odd message:

> Could not find a part of the path `C:\users\Tom\source\repos\ConsoleApp999\Program.cs\.editorconfig'.

The problem here is that the template wizard for .editorconfig files effectively assumes that if an item is selected in Solution Explorer (as opposed to a project or the top-level solution item) then that item must be a folder. It then treats the full path of that item as a path to a directory, rather than a path to a file.

The fix here is to explicitly check if the selected item is a physical file or folder. If it is a folder we can continue to treat the full path as a directory; if it is a file then we need to trim off the file name.