### PR TITLE
Fix folder name for AssemblyInfo item template

### DIFF
--- a/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop.csproj
+++ b/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop.csproj
@@ -22,7 +22,7 @@
       <OutputSubPath>.NET Core</OutputSubPath>
     </VSTemplate>
     <VSTemplate Include="AssemblyInfo\AssemblyInfo.vstemplate">
-      <OutputSubPath>.NET Core</OutputSubPath>
+      <OutputSubPath>General</OutputSubPath>
     </VSTemplate>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
@jmarolf A few questions...

Should I expect this to be F5able? Nothing changed when I F5ed the project.

Is this the correct spot? The AssemblyInfo.vstemplate doesn't show in Solution Explorer, but the other .vstemplate files in the project do. Additionally, the other .vstemplates are project templates rather than item templates.

Fixes https://github.com/dotnet/project-system/issues/5346