### PR TITLE
Add XAML language tag to WPF project templates

### DIFF
--- a/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/Wpf.Control.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/Wpf.Control.vstemplate
@@ -15,6 +15,7 @@
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
     <AppIdFilter>blend</AppIdFilter>
     <LanguageTag>C#</LanguageTag>
+    <LanguageTag>XAML</LanguageTag>
     <PlatformTag>Windows</PlatformTag>
     <ProjectTypeTag>Desktop</ProjectTypeTag>
     <ProjectTypeTag>Library</ProjectTypeTag>

--- a/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/Wpf.Custom.Control.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/Wpf.Custom.Control.vstemplate
@@ -14,7 +14,8 @@
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
     <AppIdFilter>blend</AppIdFilter>
-        <LanguageTag>C#</LanguageTag>
+    <LanguageTag>C#</LanguageTag>
+    <LanguageTag>XAML</LanguageTag>
     <PlatformTag>Windows</PlatformTag>
     <ProjectTypeTag>Desktop</ProjectTypeTag>
     <ProjectTypeTag>Library</ProjectTypeTag>

--- a/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/WpfApp.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/WpfApp.vstemplate
@@ -14,6 +14,10 @@
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
     <AppIdFilter>blend</AppIdFilter>
+    <LanguageTag>CSharp</LanguageTag>
+    <LanguageTag>XAML</LanguageTag>
+    <PlatformTag>Windows</PlatformTag>
+    <ProjectTypeTag>Desktop</ProjectTypeTag>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>

--- a/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/WpfLibrary.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetCore.CSharp.ProjectTemplates.Desktop/WpfLibrary.vstemplate
@@ -14,6 +14,11 @@
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
     <AppIdFilter>blend</AppIdFilter>
+    <LanguageTag>C#</LanguageTag>
+    <LanguageTag>XAML</LanguageTag>
+    <PlatformTag>Windows</PlatformTag>
+    <ProjectTypeTag>Desktop</ProjectTypeTag>
+    <ProjectTypeTag>Library</ProjectTypeTag>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>


### PR DESCRIPTION
Provide an easy way for developers to filter WPF projects using the XAML keyword.