### PR TITLE
Specify indent_size = 2 for XML in editorconfig (.NET) template

### DIFF
--- a/src/Tools/Microsoft.VisualStudio.Templates.Editorconfig.Wizard/TemplateConstants.cs
+++ b/src/Tools/Microsoft.VisualStudio.Templates.Editorconfig.Wizard/TemplateConstants.cs
@@ -17,11 +17,11 @@ root = true
 indent_style = space
 
 # XML project files
-[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+[*.{{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}}]
 indent_size = 2
 
 # XML config files
-[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+[*.{{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}}]
 indent_size = 2
 
 # Code files

--- a/src/Tools/Microsoft.VisualStudio.Templates.Editorconfig.Wizard/TemplateConstants.cs
+++ b/src/Tools/Microsoft.VisualStudio.Templates.Editorconfig.Wizard/TemplateConstants.cs
@@ -150,11 +150,11 @@ visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public
 indent_style = space
 
 # XML project files
-[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+[*.{{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}}]
 indent_size = 2
 
 # XML config files
-[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+[*.{{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}}]
 indent_size = 2
 
 # Code files

--- a/src/Tools/Microsoft.VisualStudio.Templates.Editorconfig.Wizard/TemplateConstants.cs
+++ b/src/Tools/Microsoft.VisualStudio.Templates.Editorconfig.Wizard/TemplateConstants.cs
@@ -15,6 +15,15 @@ root = true
 # All files
 [*]
 indent_style = space
+
+# XML project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
 # Code files
 [*.{{cs,csx,vb,vbx}}]
 indent_size = 4
@@ -139,6 +148,15 @@ visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public
 # All files
 [*]
 indent_style = space
+
+# XML project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
 # Code files
 [*.{{cs,csx,vb,vbx}}]
 indent_size = 4


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/52509

@kaylumah Please confirm if these are the changes you meant.