### PR TITLE
Move to SS pool

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -33,7 +33,7 @@ jobs:
 
 - job: Build
   pool:
-    name: VSEng-MicroBuildVS2019
+    name: VSEngSS-MicroBuild2019
     demands: Cmd
   steps:
   - checkout: self

--- a/global.json
+++ b/global.json
@@ -9,7 +9,7 @@
     "vs": {
       "version": "16.10"
     },
-    "xcopy-msbuild": "16.10.0"
+    "xcopy-msbuild": "16.10.0-preview2"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21319.2"

--- a/global.json
+++ b/global.json
@@ -7,9 +7,9 @@
   "tools": {
     "dotnet": "6.0.100-preview.4.21255.9",
     "vs": {
-      "version": "16.8"
+      "version": "16.10"
     },
-    "xcopy-msbuild": "16.8.0-preview2.1"
+    "xcopy-msbuild": "16.10.0"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "6.0.0-beta.21319.2"


### PR DESCRIPTION
Test build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4900535&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=3374e909-b3a0-5fde-4fba-1f1bb546637f

Build failed because SS2019 pool is still on VS 16.9 and NET 6 Preview 4 SDK required 16.10 