### PR TITLE
Adding templates for .NET Android, iOS and Mac Catalyst templates

### DIFF
--- a/Templates.sln
+++ b/Templates.sln
@@ -55,6 +55,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.Temp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NetMaui.CSharp.ProjectTemplates", "src\Templates\DotnetCore\Microsoft.NetMaui.CSharp.ProjectTemplates\Microsoft.NetMaui.CSharp.ProjectTemplates.csproj", "{F01D1905-707A-4495-AF80-2AE94E77EB79}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NetAndroid.CSharp.ProjectTemplates", "src\Templates\DotnetCore\Microsoft.NetAndroid.CSharp.ProjectTemplates\Microsoft.NetAndroid.CSharp.ProjectTemplates.csproj", "{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NetIOS.CSharp.ProjectTemplates", "src\Templates\DotnetCore\Microsoft.NetIOS.CSharp.ProjectTemplates\Microsoft.NetIOS.CSharp.ProjectTemplates.csproj", "{839C475B-77BD-4CC1-98FF-06590B56E2F6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NetMacCatalyst.CSharp.ProjectTemplates", "src\Templates\DotnetCore\Microsoft.NetMacCatalyst.CSharp.ProjectTemplates\Microsoft.NetMacCatalyst.CSharp.ProjectTemplates.csproj", "{B4267E93-53B1-4A5B-AF27-A71E4599D753}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -293,6 +299,42 @@ Global
 		{F01D1905-707A-4495-AF80-2AE94E77EB79}.Release|x64.Build.0 = Release|Any CPU
 		{F01D1905-707A-4495-AF80-2AE94E77EB79}.Release|x86.ActiveCfg = Release|Any CPU
 		{F01D1905-707A-4495-AF80-2AE94E77EB79}.Release|x86.Build.0 = Release|Any CPU
+		{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94}.Debug|x64.Build.0 = Debug|Any CPU
+		{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94}.Debug|x86.Build.0 = Debug|Any CPU
+		{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94}.Release|x64.ActiveCfg = Release|Any CPU
+		{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94}.Release|x64.Build.0 = Release|Any CPU
+		{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94}.Release|x86.ActiveCfg = Release|Any CPU
+		{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94}.Release|x86.Build.0 = Release|Any CPU
+		{839C475B-77BD-4CC1-98FF-06590B56E2F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{839C475B-77BD-4CC1-98FF-06590B56E2F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{839C475B-77BD-4CC1-98FF-06590B56E2F6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{839C475B-77BD-4CC1-98FF-06590B56E2F6}.Debug|x64.Build.0 = Debug|Any CPU
+		{839C475B-77BD-4CC1-98FF-06590B56E2F6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{839C475B-77BD-4CC1-98FF-06590B56E2F6}.Debug|x86.Build.0 = Debug|Any CPU
+		{839C475B-77BD-4CC1-98FF-06590B56E2F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{839C475B-77BD-4CC1-98FF-06590B56E2F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{839C475B-77BD-4CC1-98FF-06590B56E2F6}.Release|x64.ActiveCfg = Release|Any CPU
+		{839C475B-77BD-4CC1-98FF-06590B56E2F6}.Release|x64.Build.0 = Release|Any CPU
+		{839C475B-77BD-4CC1-98FF-06590B56E2F6}.Release|x86.ActiveCfg = Release|Any CPU
+		{839C475B-77BD-4CC1-98FF-06590B56E2F6}.Release|x86.Build.0 = Release|Any CPU
+		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Debug|x64.Build.0 = Debug|Any CPU
+		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Debug|x86.Build.0 = Debug|Any CPU
+		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Release|x64.ActiveCfg = Release|Any CPU
+		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Release|x64.Build.0 = Release|Any CPU
+		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Release|x86.ActiveCfg = Release|Any CPU
+		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -323,6 +365,9 @@ Global
 		{07454CA2-3BA6-47F2-A05F-CF44E69858C3} = {F467574B-E713-46CB-9C54-D70C42DD29C9}
 		{7C4C00F3-8906-4FCC-9DE9-DBE1E41F7116} = {71612166-740D-4489-86E6-0B1BD6487462}
 		{F01D1905-707A-4495-AF80-2AE94E77EB79} = {F467574B-E713-46CB-9C54-D70C42DD29C9}
+		{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94} = {F467574B-E713-46CB-9C54-D70C42DD29C9}
+		{839C475B-77BD-4CC1-98FF-06590B56E2F6} = {F467574B-E713-46CB-9C54-D70C42DD29C9}
+		{B4267E93-53B1-4A5B-AF27-A71E4599D753} = {F467574B-E713-46CB-9C54-D70C42DD29C9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6F3FC446-CADE-4812-8487-19861157EA49}

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>17.8.0</VersionPrefix>
+    <VersionPrefix>17.9.0</VersionPrefix>
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <!-- Opt-in repo features -->
     <UsingToolVSSDK>true</UsingToolVSSDK>

--- a/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidApp.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidApp.vstemplate
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET Android App</Name>
+    <Description Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4655" />
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>20</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <TemplateID>Microsoft.CSharp.NETAndroid.App</TemplateID>
+    <CreateNewFolder>true</CreateNewFolder>
+    <CreateInPlace>true</CreateInPlace>
+    <DefaultName>AndroidApp1</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+    <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+  </TemplateData>
+  <TemplateContent>
+    <ProjectCollection/>
+    <CustomParameters>
+      <CustomParameter Name="$language$" Value="C#" />
+      <CustomParameter Name="$uistyle$" Value="none" />
+      <CustomParameter Name="$groupid$" Value="Microsoft.Android.AndroidApp" />
+    </CustomParameters>
+  </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidBinding.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidBinding.vstemplate
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET Android Java Library Binding</Name>
+    <Description Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4655" />
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>21</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <TemplateID>Microsoft.CSharp.NETAndroid.Binding</TemplateID>
+    <CreateNewFolder>true</CreateNewFolder>
+    <CreateInPlace>true</CreateInPlace>
+    <DefaultName>AndroidBinding1</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+    <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+  </TemplateData>
+  <TemplateContent>
+    <ProjectCollection/>
+    <CustomParameters>
+      <CustomParameter Name="$language$" Value="C#" />
+      <CustomParameter Name="$uistyle$" Value="none" />
+      <CustomParameter Name="$groupid$" Value="Microsoft.Android.AndroidBinding" />
+    </CustomParameters>
+  </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidLib.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidLib.vstemplate
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET Android Class Library</Name>
+    <Description Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4655" />
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>22</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <TemplateID>Microsoft.CSharp.NETAndroid.Library</TemplateID>
+    <CreateNewFolder>true</CreateNewFolder>
+    <CreateInPlace>true</CreateInPlace>
+    <DefaultName>AndroidLib1</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+    <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+  </TemplateData>
+  <TemplateContent>
+    <ProjectCollection/>
+    <CustomParameters>
+      <CustomParameter Name="$language$" Value="C#" />
+      <CustomParameter Name="$uistyle$" Value="none" />
+      <CustomParameter Name="$groupid$" Value="Microsoft.Android.AndroidLib" />
+    </CustomParameters>
+  </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidWearApp.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidWearApp.vstemplate
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET Android Wear App</Name>
+    <Description Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4655" />
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>23</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <TemplateID>Microsoft.CSharp.NETAndroid.WearApp</TemplateID>
+    <CreateNewFolder>true</CreateNewFolder>
+    <CreateInPlace>true</CreateInPlace>
+    <DefaultName>AndroidApp1</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+    <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+  </TemplateData>
+  <TemplateContent>
+    <ProjectCollection/>
+    <CustomParameters>
+      <CustomParameter Name="$language$" Value="C#" />
+      <CustomParameter Name="$uistyle$" Value="none" />
+      <CustomParameter Name="$groupid$" Value="Microsoft.Android.AndroidWearApp" />
+    </CustomParameters>
+  </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/Microsoft.NetAndroid.CSharp.ProjectTemplates.csproj
+++ b/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/Microsoft.NetAndroid.CSharp.ProjectTemplates.csproj
@@ -1,0 +1,22 @@
+﻿<!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <VSTemplate Include="AndroidApp.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+    <VSTemplate Include="AndroidBinding.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+    <VSTemplate Include="AndroidLib.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+    <VSTemplate Include="AndroidWearApp.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+  </ItemGroup>
+</Project>

--- a/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/source.extension.vsixmanifest
+++ b/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/source.extension.vsixmanifest
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="Microsoft.NetAndroid.CSharp.ProjectTemplates" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <DisplayName>C# .NET Android Project Templates</DisplayName>
+    <Description>C# project templates for .NET Android.</Description>
+  </Metadata>
+  <Installation Experimental="true">
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.VSWinDesktopExpress" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.VWDExpress" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.VSWinExpress" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.TemplateEngine" Version="[17.0,)" DisplayName="ASP.NET templating engine" />
+  </Prerequisites>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="AndroidApp" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="AndroidBinding" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="AndroidLib" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="AndroidWearApp" />
+  </Assets>
+</PackageManifest>

--- a/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSApp.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSApp.vstemplate
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET iOS App</Name>
+    <Description Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4655" />
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>24</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <TemplateID>Microsoft.CSharp.NETiOS.App</TemplateID>
+    <CreateNewFolder>true</CreateNewFolder>
+    <CreateInPlace>true</CreateInPlace>
+    <DefaultName>iOSApp1</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+    <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+  </TemplateData>
+  <TemplateContent>
+    <ProjectCollection/>
+    <CustomParameters>
+      <CustomParameter Name="$language$" Value="C#" />
+      <CustomParameter Name="$uistyle$" Value="none" />
+      <CustomParameter Name="$groupid$" Value="Microsoft.iOS.iOSApp" />
+    </CustomParameters>
+  </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSBindingLib.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSBindingLib.vstemplate
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET iOS Binding Library</Name>
+    <Description Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4655" />
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>25</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <TemplateID>Microsoft.CSharp.NETiOS.Binding</TemplateID>
+    <CreateNewFolder>true</CreateNewFolder>
+    <CreateInPlace>true</CreateInPlace>
+    <DefaultName>iOSBinding1</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+    <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+  </TemplateData>
+  <TemplateContent>
+    <ProjectCollection/>
+    <CustomParameters>
+      <CustomParameter Name="$language$" Value="C#" />
+      <CustomParameter Name="$uistyle$" Value="none" />
+      <CustomParameter Name="$groupid$" Value="Microsoft.iOS.iOSBinding" />
+    </CustomParameters>
+  </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSClassLib.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSClassLib.vstemplate
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET iOS Class Library</Name>
+    <Description Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4655" />
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>26</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <TemplateID>Microsoft.CSharp.NETiOS.Library</TemplateID>
+    <CreateNewFolder>true</CreateNewFolder>
+    <CreateInPlace>true</CreateInPlace>
+    <DefaultName>iOSLib1</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+    <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+  </TemplateData>
+  <TemplateContent>
+    <ProjectCollection/>
+    <CustomParameters>
+      <CustomParameter Name="$language$" Value="C#" />
+      <CustomParameter Name="$uistyle$" Value="none" />
+      <CustomParameter Name="$groupid$" Value="Microsoft.iOS.iOSLib" />
+    </CustomParameters>
+  </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSTabbed.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSTabbed.vstemplate
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET iOS Tabbed App</Name>
+    <Description Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4655" />
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>27</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <TemplateID>Microsoft.CSharp.NETiOS.TabbedApp</TemplateID>
+    <CreateNewFolder>true</CreateNewFolder>
+    <CreateInPlace>true</CreateInPlace>
+    <DefaultName>iOSTabbedApp1</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+    <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+  </TemplateData>
+  <TemplateContent>
+    <ProjectCollection/>
+    <CustomParameters>
+      <CustomParameter Name="$language$" Value="C#" />
+      <CustomParameter Name="$uistyle$" Value="none" />
+      <CustomParameter Name="$groupid$" Value="Microsoft.iOS.iOSTabbedApp" />
+    </CustomParameters>
+  </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/Microsoft.NetIOS.CSharp.ProjectTemplates.csproj
+++ b/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/Microsoft.NetIOS.CSharp.ProjectTemplates.csproj
@@ -1,0 +1,22 @@
+﻿<!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <VSTemplate Include="IOSApp.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+    <VSTemplate Include="IOSBinding.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+    <VSTemplate Include="IOSClassLib.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+    <VSTemplate Include="IOSTabbed.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+  </ItemGroup>
+</Project>

--- a/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/source.extension.vsixmanifest
+++ b/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/source.extension.vsixmanifest
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="Microsoft.NetIOS.CSharp.ProjectTemplates" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <DisplayName>C# .NET iOS Project Templates</DisplayName>
+    <Description>C# project templates for .NET iOS.</Description>
+  </Metadata>
+  <Installation Experimental="true">
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.VSWinDesktopExpress" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.VWDExpress" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.VSWinExpress" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.TemplateEngine" Version="[17.0,)" DisplayName="ASP.NET templating engine" />
+  </Prerequisites>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="IOSApp" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="IOSBinding" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="IOSClassLib" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="IOSTabbed" />
+  </Assets>
+</PackageManifest>

--- a/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/MacCatalystApp.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/MacCatalystApp.vstemplate
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET Mac Catalyst App</Name>
+    <Description Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4655" />
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>28</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <TemplateID>Microsoft.CSharp.NETMacCatalyst.App</TemplateID>
+    <CreateNewFolder>true</CreateNewFolder>
+    <CreateInPlace>true</CreateInPlace>
+    <DefaultName>MacCatalystApp1</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+    <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+  </TemplateData>
+  <TemplateContent>
+    <ProjectCollection/>
+    <CustomParameters>
+      <CustomParameter Name="$language$" Value="C#" />
+      <CustomParameter Name="$uistyle$" Value="none" />
+      <CustomParameter Name="$groupid$" Value="Microsoft.MacCatalyst.MacCatalystApp" />
+    </CustomParameters>
+  </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/MacCatalystBinding.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/MacCatalystBinding.vstemplate
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET Mac Catalyst Binding Library</Name>
+    <Description Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4655" />
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>29</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <TemplateID>Microsoft.CSharp.NETMacCatalyst.Binding</TemplateID>
+    <CreateNewFolder>true</CreateNewFolder>
+    <CreateInPlace>true</CreateInPlace>
+    <DefaultName>MacCatalystBinding1</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+    <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+  </TemplateData>
+  <TemplateContent>
+    <ProjectCollection/>
+    <CustomParameters>
+      <CustomParameter Name="$language$" Value="C#" />
+      <CustomParameter Name="$uistyle$" Value="none" />
+      <CustomParameter Name="$groupid$" Value="Microsoft.MacCatalyst.MacCatalystBinding" />
+    </CustomParameters>
+  </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/MacCatalystLibrary.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/MacCatalystLibrary.vstemplate
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET Mac Catalyst Class Library</Name>
+    <Description Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4655" />
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>30</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <TemplateID>Microsoft.CSharp.NETMacCatalyst.Library</TemplateID>
+    <CreateNewFolder>true</CreateNewFolder>
+    <CreateInPlace>true</CreateInPlace>
+    <DefaultName>MacCatalystLib1</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+    <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+  </TemplateData>
+  <TemplateContent>
+    <ProjectCollection/>
+    <CustomParameters>
+      <CustomParameter Name="$language$" Value="C#" />
+      <CustomParameter Name="$uistyle$" Value="none" />
+      <CustomParameter Name="$groupid$" Value="Microsoft.MacCatalyst.MacCatalystLib" />
+    </CustomParameters>
+  </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates.csproj
+++ b/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates.csproj
@@ -1,0 +1,19 @@
+﻿<!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <VSTemplate Include="MacCatalystApp.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+    <VSTemplate Include="MacCatalystBinding.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+    <VSTemplate Include="MacCatalystLibrary.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+  </ItemGroup>
+</Project>

--- a/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/source.extension.vsixmanifest
+++ b/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/source.extension.vsixmanifest
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="Microsoft.NetMacCatalyst.CSharp.ProjectTemplates" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <DisplayName>C# .NET Mac Catalyst Project Templates</DisplayName>
+    <Description>C# project templates for .NET Mac Catalyst.</Description>
+  </Metadata>
+  <Installation Experimental="true">
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.VSWinDesktopExpress" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.VWDExpress" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.VSWinExpress" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.TemplateEngine" Version="[17.0,)" DisplayName="ASP.NET templating engine" />
+  </Prerequisites>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="MacCatalystApp" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="MacCatalystBinding" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="MacCatalystLibrary" />
+  </Assets>
+</PackageManifest>


### PR DESCRIPTION
Similar to this change I made a while ago: https://github.com/dotnet/templates/pull/762

That change added the .NET MAUI (multi-platform) templates.  This one adds the templates that specifically target the Android, iOS and MacCatalyst platforms.