### PR TITLE
Adding Hidden template data to new .NET MAUI, Android, iOS and MacCatalyst templates

### DIFF
--- a/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidApp.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidApp.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>AndroidApp1</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <Hidden>true</Hidden>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>

--- a/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidBinding.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidBinding.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>AndroidBinding1</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <Hidden>true</Hidden>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>

--- a/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidLib.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidLib.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>AndroidLib1</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <Hidden>true</Hidden>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>

--- a/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidWearApp.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetAndroid.CSharp.ProjectTemplates/AndroidWearApp.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>AndroidApp1</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <Hidden>true</Hidden>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>

--- a/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSApp.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSApp.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>iOSApp1</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <Hidden>true</Hidden>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>

--- a/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSBinding.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSBinding.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>iOSBinding1</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <Hidden>true</Hidden>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>

--- a/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSClassLib.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSClassLib.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>iOSLib1</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <Hidden>true</Hidden>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>

--- a/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSTabbed.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetIOS.CSharp.ProjectTemplates/IOSTabbed.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>iOSTabbedApp1</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <Hidden>true</Hidden>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>

--- a/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/MacCatalystApp.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/MacCatalystApp.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>MacCatalystApp1</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <Hidden>true</Hidden>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>

--- a/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/MacCatalystBinding.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/MacCatalystBinding.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>MacCatalystBinding1</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <Hidden>true</Hidden>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>

--- a/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/MacCatalystLibrary.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMacCatalyst.CSharp.ProjectTemplates/MacCatalystLibrary.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>MacCatalystLib1</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <Hidden>true</Hidden>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>

--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ProjectTemplates/MauiBlazor.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ProjectTemplates/MauiBlazor.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>MauiApp1</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <Hidden>true</Hidden>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>

--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ProjectTemplates/MauiLib.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ProjectTemplates/MauiLib.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>MauiLib1</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <Hidden>true</Hidden>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>

--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ProjectTemplates/MauiMobile.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ProjectTemplates/MauiMobile.vstemplate
@@ -13,6 +13,7 @@
     <DefaultName>MauiApp1</DefaultName>
     <ProvideDefaultName>true</ProvideDefaultName>
     <PromptForSaveOnCreation>true</PromptForSaveOnCreation>
+    <Hidden>true</Hidden>
   </TemplateData>
   <TemplateContent>
     <ProjectCollection/>


### PR DESCRIPTION
These templates I added recently are there to enable DTE project creation, they're not supposed to be visible in NPD.  So, I'm adding the Hidden=true template setting.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1905370