### PR TITLE
Adding .NET MAUI Item Templates

### DIFF
--- a/Templates.sln
+++ b/Templates.sln
@@ -61,6 +61,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NetIOS.CSharp.Pro
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NetMacCatalyst.CSharp.ProjectTemplates", "src\Templates\DotnetCore\Microsoft.NetMacCatalyst.CSharp.ProjectTemplates\Microsoft.NetMacCatalyst.CSharp.ProjectTemplates.csproj", "{B4267E93-53B1-4A5B-AF27-A71E4599D753}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.NetMaui.CSharp.ItemTemplates", "src\Templates\DotnetCore\Microsoft.NetMaui.CSharp.ItemTemplates\Microsoft.NetMaui.CSharp.ItemTemplates.csproj", "{E8F37FD2-BE33-4AB5-9F5E-9EC4E982BB79}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -335,6 +337,18 @@ Global
 		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Release|x64.Build.0 = Release|Any CPU
 		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Release|x86.ActiveCfg = Release|Any CPU
 		{B4267E93-53B1-4A5B-AF27-A71E4599D753}.Release|x86.Build.0 = Release|Any CPU
+		{E8F37FD2-BE33-4AB5-9F5E-9EC4E982BB79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8F37FD2-BE33-4AB5-9F5E-9EC4E982BB79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8F37FD2-BE33-4AB5-9F5E-9EC4E982BB79}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E8F37FD2-BE33-4AB5-9F5E-9EC4E982BB79}.Debug|x64.Build.0 = Debug|Any CPU
+		{E8F37FD2-BE33-4AB5-9F5E-9EC4E982BB79}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E8F37FD2-BE33-4AB5-9F5E-9EC4E982BB79}.Debug|x86.Build.0 = Debug|Any CPU
+		{E8F37FD2-BE33-4AB5-9F5E-9EC4E982BB79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8F37FD2-BE33-4AB5-9F5E-9EC4E982BB79}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8F37FD2-BE33-4AB5-9F5E-9EC4E982BB79}.Release|x64.ActiveCfg = Release|Any CPU
+		{E8F37FD2-BE33-4AB5-9F5E-9EC4E982BB79}.Release|x64.Build.0 = Release|Any CPU
+		{E8F37FD2-BE33-4AB5-9F5E-9EC4E982BB79}.Release|x86.ActiveCfg = Release|Any CPU
+		{E8F37FD2-BE33-4AB5-9F5E-9EC4E982BB79}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -368,6 +382,7 @@ Global
 		{7F7ABDA3-AAB6-4B62-B5DC-1F30B92EFF94} = {F467574B-E713-46CB-9C54-D70C42DD29C9}
 		{839C475B-77BD-4CC1-98FF-06590B56E2F6} = {F467574B-E713-46CB-9C54-D70C42DD29C9}
 		{B4267E93-53B1-4A5B-AF27-A71E4599D753} = {F467574B-E713-46CB-9C54-D70C42DD29C9}
+		{E8F37FD2-BE33-4AB5-9F5E-9EC4E982BB79} = {F467574B-E713-46CB-9C54-D70C42DD29C9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6F3FC446-CADE-4812-8487-19861157EA49}

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>17.9.0</VersionPrefix>
+    <VersionPrefix>17.10.0</VersionPrefix>
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
     <!-- Opt-in repo features -->
     <UsingToolVSSDK>true</UsingToolVSSDK>

--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentPageCS.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentPageCS.vstemplate
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET MAUI Content Page (C#)</Name>
+    <Description>A page for displaying content using C#.</Description>
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <TemplateID>Microsoft.CSharp.NETMAUI.ContentPage</TemplateID>
+    <AppliesTo>CSharp</AppliesTo>
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>110</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <DefaultName>NewPage1.cs</DefaultName>
+    <ShowByDefault>false</ShowByDefault>
+    <Hidden>true</Hidden>
+  </TemplateData>
+  <TemplateContent>
+    <CustomParameters>
+      <CustomParameter Name="$groupid$" Value="Microsoft.Maui.CSharpContentPage" />
+    </CustomParameters>
+  </TemplateContent>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentPageXaml.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentPageXaml.vstemplate
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET MAUI Content Page (XAML)</Name>
+    <Description>A page for displaying content using XAML.</Description>
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <TemplateID>Microsoft.CSharp.NETMAUI.XamlContentPage</TemplateID>
+    <AppliesTo>CSharp</AppliesTo>
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>111</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <DefaultName>NewPage1.xaml</DefaultName>
+    <ShowByDefault>false</ShowByDefault>
+    <Hidden>true</Hidden>
+  </TemplateData>
+  <TemplateContent>
+    <CustomParameters>
+      <CustomParameter Name="$groupid$" Value="Microsoft.Maui.XamlContentPage" />
+    </CustomParameters>
+  </TemplateContent>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentViewCS.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentViewCS.vstemplate
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET MAUI Content View (C#)</Name>
+    <Description>A view for displaying content using C#. This is very suitable for creating your own custom and reusable controls.</Description>
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <TemplateID>Microsoft.CSharp.NETMAUI.ContentView</TemplateID>
+    <AppliesTo>CSharp</AppliesTo>
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>112</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <DefaultName>NewContent1.cs</DefaultName>
+    <ShowByDefault>false</ShowByDefault>
+    <Hidden>true</Hidden>
+  </TemplateData>
+  <TemplateContent>
+    <CustomParameters>
+      <CustomParameter Name="$groupid$" Value="Microsoft.Maui.CSharpContentView" />
+    </CustomParameters>
+  </TemplateContent>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentViewXaml.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentViewXaml.vstemplate
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET MAUI Content View (XAML)</Name>
+    <Description>A view for displaying content using XAML. This is very suitable for creating your own custom and reusable controls.</Description>
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <TemplateID>Microsoft.CSharp.NETMAUI.XamlContentView</TemplateID>
+    <AppliesTo>CSharp</AppliesTo>
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>113</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <DefaultName>NewContent1.xaml</DefaultName>
+    <ShowByDefault>false</ShowByDefault>
+    <Hidden>true</Hidden>
+  </TemplateData>
+  <TemplateContent>
+    <CustomParameters>
+      <CustomParameter Name="$groupid$" Value="Microsoft.Maui.XamlContentView" />
+    </CustomParameters>
+  </TemplateContent>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiXamlResourceDictionary.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiXamlResourceDictionary.vstemplate
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<VSTemplate Version="3.0.0" Type="Item" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+  <TemplateData>
+    <Name>.NET MAUI Resource Dictionary (XAML)</Name>
+    <Description>A repository for resources that are used by a .NET MAUI app. Typical resources that are stored in a ResourceDictionary include styles, control templates, data templates, converters, and colors.</Description>
+    <Icon Package="{b3bae735-386c-4030-8329-ef48eeda4036}" ID="4600" />
+    <TemplateID>Microsoft.CSharp.NETMAUI.XamlResourceDictionary</TemplateID>
+    <AppliesTo>CSharp</AppliesTo>
+    <ProjectType>CSharp</ProjectType>
+    <SortOrder>114</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <DefaultName>Dictionary1.xaml</DefaultName>
+    <ShowByDefault>false</ShowByDefault>
+    <Hidden>true</Hidden>
+  </TemplateData>
+  <TemplateContent>
+    <CustomParameters>
+      <CustomParameter Name="$groupid$" Value="Microsoft.Maui.XamlResourceDictionary" />
+    </CustomParameters>
+  </TemplateContent>
+</VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/Microsoft.NetMaui.CSharp.ItemTemplates.csproj
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/Microsoft.NetMaui.CSharp.ItemTemplates.csproj
@@ -1,0 +1,25 @@
+﻿<!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <VSTemplate Include="MauiContentPageCS.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+    <VSTemplate Include="MauiContentPageXaml.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+    <VSTemplate Include="MauiContentViewCS.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+    <VSTemplate Include="MauiContentViewXaml.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+    <VSTemplate Include="MauiXamlResourceDictionary.vstemplate">
+      <OutputSubPath>.NET</OutputSubPath>
+    </VSTemplate>
+  </ItemGroup>
+</Project>

--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/source.extension.vsixmanifest
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/source.extension.vsixmanifest
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="Microsoft.NetMaui.CSharp.ItemTemplates" Version="|%CurrentProject%;GetVsixVersion|" Language="en-US" Publisher="Microsoft" />
+    <DisplayName>C# .NET MAUI Item Templates</DisplayName>
+    <Description>C# item templates for .NET MAUI.</Description>
+  </Metadata>
+  <Installation Experimental="true">
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.VSWinDesktopExpress" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.VWDExpress" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.VSWinExpress" Version="[17.0,]">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions.TemplateEngine" Version="[17.0,)" DisplayName="ASP.NET templating engine" />
+  </Prerequisites>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" Path="MauiContentPageCS" />
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" Path="MauiContentPageXaml" />
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" Path="MauiContentViewCS" />
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" Path="MauiContentViewXAML" />
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" Path="MauiXamlResourceDictionary" />
+  </Assets>
+</PackageManifest>


### PR DESCRIPTION
This is similar to this change that I made recently that enables DTE creation of .NET MAUI Project templates: #762 

The difference here is that I'm now adding support for the .NET MAUI Item templates, as seen below.

![image](https://github.com/dotnet/templates/assets/42553283/6fd6985c-d4f7-4e5e-a63e-c4bf36ae5645)

Bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1935534