### PR TITLE
Adding missing WizardExtension and CustomParameter elements to MAUI item templates

### DIFF
--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentPageCS.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentPageCS.vstemplate
@@ -15,7 +15,13 @@
   </TemplateData>
   <TemplateContent>
     <CustomParameters>
+      <CustomParameter Name="$uistyle$" Value="none" />
       <CustomParameter Name="$groupid$" Value="Microsoft.Maui.CSharpContentPage" />
+      <CustomParameter Name="$language$" Value="C#" />
     </CustomParameters>
   </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
 </VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentPageXaml.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentPageXaml.vstemplate
@@ -15,7 +15,13 @@
   </TemplateData>
   <TemplateContent>
     <CustomParameters>
+      <CustomParameter Name="$uistyle$" Value="none" />
       <CustomParameter Name="$groupid$" Value="Microsoft.Maui.XamlContentPage" />
+      <CustomParameter Name="$language$" Value="C#" />
     </CustomParameters>
   </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
 </VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentViewCS.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentViewCS.vstemplate
@@ -15,7 +15,13 @@
   </TemplateData>
   <TemplateContent>
     <CustomParameters>
+      <CustomParameter Name="$uistyle$" Value="none" />
       <CustomParameter Name="$groupid$" Value="Microsoft.Maui.CSharpContentView" />
+      <CustomParameter Name="$language$" Value="C#" />
     </CustomParameters>
   </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
 </VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentViewXaml.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiContentViewXaml.vstemplate
@@ -15,7 +15,13 @@
   </TemplateData>
   <TemplateContent>
     <CustomParameters>
+      <CustomParameter Name="$uistyle$" Value="none" />
       <CustomParameter Name="$groupid$" Value="Microsoft.Maui.XamlContentView" />
+      <CustomParameter Name="$language$" Value="C#" />
     </CustomParameters>
   </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
 </VSTemplate>

--- a/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiXamlResourceDictionary.vstemplate
+++ b/src/Templates/DotnetCore/Microsoft.NetMaui.CSharp.ItemTemplates/MauiXamlResourceDictionary.vstemplate
@@ -15,7 +15,13 @@
   </TemplateData>
   <TemplateContent>
     <CustomParameters>
+      <CustomParameter Name="$uistyle$" Value="none" />
       <CustomParameter Name="$groupid$" Value="Microsoft.Maui.XamlResourceDictionary" />
+      <CustomParameter Name="$language$" Value="C#" />
     </CustomParameters>
   </TemplateContent>
+  <WizardExtension>
+    <Assembly>Microsoft.VisualStudio.TemplateEngine.Wizard, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</Assembly>
+    <FullClassName>Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard</FullClassName>
+  </WizardExtension>
 </VSTemplate>


### PR DESCRIPTION
I recently added these templates, but they're not working as expected.  So, I'm adding some previously missing values, following the example show here: https://devdiv.visualstudio.com/DevDiv/_git/WebTools-Templates?path=/src/Templates/ItemTemplates/AspNetCore/Web/ASP.NET/RazorComponent/RazorComponent.vstemplate